### PR TITLE
build.sh: In times of crisis, CCache is king

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,11 +35,11 @@ function make_kernel() {
   echo -e "$cyan***********************************************"
   echo -e "          Initializing defconfig          "
   echo -e "***********************************************$nocol"
-  make $defconfig CC=clang O=output/
+  make $defconfig CC='ccache clang  -Qunused-arguments -fcolor-diagnostics' O=output/
   echo -e "$cyan***********************************************"
   echo -e "             Building kernel          "
   echo -e "***********************************************$nocol"
-  make -j$(nproc --all) CC=clang O=output/
+  make -j$(nproc --all) CC='ccache clang  -Qunused-arguments -fcolor-diagnostics' O=output/
   if ! [ -a $KERNEL_IMG ];
   then
     echo -e "$red Kernel Compilation failed! Fix the errors! $nocol"


### PR DESCRIPTION
Correct the ccache invocation when using clang compiler.

References:
https://petereisentraut.blogspot.com/2011/05/ccache-and-clang.html
https://petereisentraut.blogspot.com/2011/09/ccache-and-clang-part-2.html
https://peter.eisentraut.org/blog/2014/12/01/ccache-and-clang-part-3/